### PR TITLE
close logger stack

### DIFF
--- a/library/logger/zap/zap.go
+++ b/library/logger/zap/zap.go
@@ -94,7 +94,7 @@ func NewLogger(options ...Option) (l *ZapLogger, err error) {
 
 	l.Logger = zap.New(core,
 		zap.AddCaller(),
-		zap.AddStacktrace(errorEnabler),
+		// zap.AddStacktrace(errorEnabler),
 		zap.AddCallerSkip(l.opts.callSkip),
 		zap.Fields(fields...),
 	)


### PR DESCRIPTION
File and func is enough to help us locate problems,  close stack can reduce log size.